### PR TITLE
Filter input containing . leading to errors.

### DIFF
--- a/src/commands/dice.rs
+++ b/src/commands/dice.rs
@@ -122,8 +122,6 @@ fn create_result<'a>(input: &'a str) -> Option<(Vec<Roll>, Box<Vec<&'a str>>)> {
         );
         return None;
     }
-    println!("{:?}", operations);
-    println!("{:?}", input_split);
     let mut rolls: Vec<Roll> = vec![];
     for token in input_split {
         let token = token.trim();


### PR DESCRIPTION
Also works when the first part of the roll doesn't contain [wWdD]